### PR TITLE
修复事件类型错误

### DIFF
--- a/types/core/common.d.ts
+++ b/types/core/common.d.ts
@@ -3,7 +3,7 @@ declare namespace AMap {
     type LocationValue = LngLat | [number, number];
     type Lang = 'zh_cn' | 'en' | 'zh_en';
 
-    type Event<N extends string = string, V = undefined> = { type: N } &
+    type Event<N extends string = string, V = any> = { type: N } &
         (V extends HTMLElement ? { value: V }
             : V extends object ? V
             : V extends undefined ? {}


### PR DESCRIPTION
``` js
map.on('rightclick', (event: AMap.Map.EventMap['rightclick']) => {});
```

Argument of type '(event: Event<"rightclick", { lnglat: LngLat; pixel: Pixel; target: Map; }>) => void' is not assignable to parameter of type '(this: Map, event: Event<string, undefined>) => void'